### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-##CHANGELOG:
+## CHANGELOG:
 * v1.5b Fixed issue with dirb
 * v1.5a Removed clear command
 * v1.5 Added install.sh

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # BruteX by 1N3@CrowdShield
 https://crowdshield.com 
 
-##Automatically brute force all services running on a target
+## Automatically brute force all services running on a target
 
 * Open ports
 * DNS domains
 * Usernames
 * Passwords
 
-##INSTALL:
+## INSTALL:
 ```
 ./install.sh
 ```
 
-##USAGE:
+## USAGE:
 ```
 brutex target <port>
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
