### PR TITLE
updated vnc & snmp hydra options

### DIFF
--- a/brutex
+++ b/brutex
@@ -164,7 +164,7 @@ then
 	echo -e "$COLOR1 + -- --=[Port 162 closed... skipping.$RESET"
 else
 	echo -e "$COLOR2 + -- --=[Port 162 opened... running tests...$RESET"
-	hydra -L $SNMP_FILE -P $SNMP_FILE snmp -S 162 -t $THREADS -e ns
+	hydra -P $SNMP_FILE snmp -S 162 -t $THREADS -e ns
 fi
 
 if [ -z "$port_389" ]
@@ -269,7 +269,7 @@ then
 	echo -e "$COLOR1 + -- --=[Port 5900 closed... skipping.$RESET"
 else
 	echo -e "$COLOR2 + -- --=[Port 5900 opened... running tests...$RESET"
-	hydra -L $USER_FILE -P $PASS_FILE $TARGET vnc -S 5900 -t $THREADS -e ns
+	hydra -P $PASS_FILE $TARGET vnc -S 5900 -t $THREADS -e ns
 fi
 
 if [ -z "$port_5901" ]
@@ -277,7 +277,7 @@ then
 	echo -e "$COLOR1 + -- --=[Port 5901 closed... skipping.$RESET"
 else
 	echo -e "$COLOR2 + -- --=[Port 5901 opened... running tests...$RESET"
-	hydra -L $USER_FILE -P $PASS_FILE $TARGET vnc -S 5901 -t $THREADS -e ns
+	hydra -P $PASS_FILE $TARGET vnc -S 5901 -t $THREADS -e ns
 fi
 
 if [ -z "$port_8000" ]


### PR DESCRIPTION
vnc and snmp do not use login or -L options. They only use passwords/community strings so I removed the -L options for vnc and snmp guessing.